### PR TITLE
Use the higher resolution result image

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/html5_notifier/RunNotification.java
+++ b/src/main/java/org/jenkins/ci/plugins/html5_notifier/RunNotification.java
@@ -108,7 +108,7 @@ public final class RunNotification extends RunListener<Run<?, ?>> implements
 
         jsonObject.put("project", run.getParent().getName());
         jsonObject.put("result", run.getResult().toString());
-        jsonObject.put("result_icon", rootUrl + "/images/16x16/" + result.color.getImage());
+        jsonObject.put("result_icon", rootUrl + "/images/48x48/" + result.color.getImage());
         jsonObject.put("url", rootUrl + run.getUrl());
         jsonObject.put("name", run.getFullDisplayName());
 


### PR DESCRIPTION
The '16x16' icon was looking too pixelated so I switched to the '48x48'.

![image](https://cloud.githubusercontent.com/assets/1719417/7091250/77a5f092-df76-11e4-8554-26ac300894f9.png)
